### PR TITLE
Add interpreter line to python scripts

### DIFF
--- a/accessory/get_DE_events.py
+++ b/accessory/get_DE_events.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 #################################### REDI OUT TABLE ########################################################
 #Region		Position	Reference	Strand	Coverage-q30	MeanQ	BaseCount[A,C,G,T]	   #
 #AllSubs	Frequency	gCoverage-q30	gMeanQ	gBaseCount[A,C,G,T]	gAllSubs	gFrequency #

--- a/accessory/readPsl.py
+++ b/accessory/readPsl.py
@@ -1,4 +1,4 @@
-
+#!/usr/bin/env python
 import sys, os
 import math
 

--- a/accessory/subCount.py
+++ b/accessory/subCount.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys
 
 try:

--- a/accessory/subCount2.py
+++ b/accessory/subCount2.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 import sys
 
 try:

--- a/main/REDItoolDenovo.py
+++ b/main/REDItoolDenovo.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python
 # coding=utf-8
 # Copyright (c) 2013-2014 Ernesto Picardi <ernesto.picardi@uniba.it>
 #


### PR DESCRIPTION
This PR adds interpreter lines to python scripts that did not have them.
Without the interpreter lines present the installation will install the
scripts without an interpreter and they will not run without specifying
the interpreter explicitly on the command line.