### PR TITLE
Fix mixed space/tab usage

### DIFF
--- a/main/REDItoolDenovo.py
+++ b/main/REDItoolDenovo.py
@@ -768,7 +768,7 @@ ridxinfo=pysam.idxstats(bamfile)
 for j in ridxinfo.split('\n'): #MOD
 	l=(j.strip()).split('\t')
 	if l[0] in ['*', '']: continue  #MOD
- 	if int(l[2])+int(l[3]) > 0: rrefs[l[0]]=int(l[1])
+	if int(l[2])+int(l[3]) > 0: rrefs[l[0]]=int(l[1])
 frefs=[]
 fidxinfo=open(fastafile+'.fai')
 for j in fidxinfo:


### PR DESCRIPTION
There is a line in REDItoolDenovo.py with mixed tabs and spaces that
causes an error when run.