### PR TITLE
Set description to README_1.md in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name='REDItools',
           'Operating System :: POSIX',
           'Programming Language :: Python',
           ],
-	long_description=open('README').read(),
+	long_description=open('README_1.md').read(),
 	platforms=['Linux','Unix','MacOS']
 )
 


### PR DESCRIPTION
Point to 'README_1.md' as 'README' does not exist.